### PR TITLE
Adjusted rule not to underscore forced test body

### DIFF
--- a/src/noFocusedTestsRule.ts
+++ b/src/noFocusedTestsRule.ts
@@ -14,10 +14,11 @@ export class Rule extends Lint.Rules.AbstractRule {
 class NoFocusedTestsWalker extends Lint.RuleWalker {
   public visitCallExpression(node: ts.CallExpression) {
     let regex = new RegExp("^(" + Rule.PROHIBITED.join("|") + ")$");
+    let match = node.expression.getText().match(regex);
 
-    if (node.expression.getText().match(regex)) {
+    if (match) {
       // create a failure at the current position
-      this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+      this.addFailure(this.createFailure(node.getStart(), match[0].length, Rule.FAILURE_STRING));
     }
 
     // call the base version of this visitor to actually parse this node

--- a/test/noFocusedTestsRule.spec.ts
+++ b/test/noFocusedTestsRule.spec.ts
@@ -16,8 +16,8 @@ fdescribe('my test', () => {
                    character: 0
                },
                endPosition: {
-                   line: 4,
-                   character: 2
+                   line: 1,
+                   character: 9
                }
            }, ['camelCase', 'ng']);
         });
@@ -38,8 +38,8 @@ describe('my test', () => {
                     character: 4
                 },
                 endPosition: {
-                    line: 5,
-                    character: 6
+                    line: 2,
+                    character: 13
                 }
             }, ['camelCase', 'ng']);
         });
@@ -60,8 +60,8 @@ describe('my test', () => {
                     character: 4
                 },
                 endPosition: {
-                    line: 3,
-                    character: 6
+                    line: 2,
+                    character: 7
                 }
             }, ['camelCase', 'ng']);
         });


### PR DESCRIPTION
It is really annoying that tslint plugin within my Visual Code underscores whole test (suite) block. I have adjusted your rule to limit underscore to `fdescribe` or `fit` keyword.