### PR TITLE
Added rule for no disabled tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Then reference the rules in your `tslint.json` and enable the rules you want:
 
 ```json
 {
-  "no-focused-tests": true
+  "no-focused-tests": true,
+  "no-disabled-tests": true
 }
 ```
 

--- a/src/noDisabledTestsRule.ts
+++ b/src/noDisabledTestsRule.ts
@@ -1,0 +1,26 @@
+import * as Lint from "tslint";
+import * as ts from "typescript";
+
+export class Rule extends Lint.Rules.AbstractRule {
+  public static FAILURE_STRING = "Disabled test (xit or xdescribe)";
+  public static PROHIBITED = ["xdescribe", "xit"];
+
+  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    return this.applyWithWalker(new NoDisabledTestsWalker(sourceFile, this.getOptions()));
+  }
+}
+
+const regex = new RegExp("^(" + Rule.PROHIBITED.join("|") + ")$");
+
+// tslint:disable-next-line:max-classes-per-file
+class NoDisabledTestsWalker extends Lint.RuleWalker {
+  public visitCallExpression(node: ts.CallExpression) {
+    const match = node.expression.getText().match(regex);
+
+    if (match) {
+      this.addFailureAt(node.getStart(), match[0].length, Rule.FAILURE_STRING);
+    }
+
+    super.visitCallExpression(node);
+  }
+}

--- a/test/noDisabledTests.ts.lint
+++ b/test/noDisabledTests.ts.lint
@@ -1,0 +1,11 @@
+describe(() => {});
+
+xdescribe(() => {});
+~~~~~~~~~ [no-disabled-tests]
+
+it(() => {});
+
+xit(() => {});
+~~~ [no-disabled-tests]
+
+[no-disabled-tests]: Disabled test (xit or xdescribe)

--- a/test/tslint.json
+++ b/test/tslint.json
@@ -1,6 +1,7 @@
 {
   "rulesDirectory": "../dist",
   "rules": {
-    "no-focused-tests": true
+    "no-focused-tests": true,
+    "no-disabled-tests": true
   }
 }


### PR DESCRIPTION
I used the existing pattern to create a new rule for disallowing disabled tests (`xdescribe` and `xit`)

I'm using your package already for its `no-focused-tests` rule, and `no-disabled-tests` seemed like a useful addition to me. (It's also a commonly-used rule in [eslint-plugin-jasmine](https://github.com/tlvince/eslint-plugin-jasmine), so I thought a similar rule could be equally useful in tslint.)

Happy to make any changes / updates you'd like.