### PR TITLE
Fix 'main' entry point declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tslint-jasmine-rules",
   "version": "1.3.1",
   "description": "tslint rules for jasmine",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
     "release": "rimraf dist && tsc && npm t",
     "test": "rimraf dist && tsc && tslint --test test",


### PR DESCRIPTION
The `index.ts` file gets published into the `dist` folder. So the `main` entry point should be called out as `dist/index.js`, not merely `index.js`.