### PR TITLE
Add support for tslint@>=5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-jasmine-rules",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -260,26 +260,18 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://ksq-b-ai-p34:443/api/npm/npm/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://ksq-b-ai-p34:443/api/npm/npm/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://ksq-b-ai-p34:443/api/npm/npm/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        }
+        "minimist": "^1.2.5"
       }
     },
     "once": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "typescript": "^2.9.2"
   },
   "peerDependencies": {
-    "tslint": "^5.0.0"
+    "tslint": ">=5.0.0"
   }
 }


### PR DESCRIPTION
Resolves: https://github.com/kaiza/tslint-jasmine-rules/issues/19

@kaiza Our project uses TSLint 6.0, but `tslint-jasmine-rules` is throwing a peer dependency warning for TSLint `^5`. Any hope of getting this in?